### PR TITLE
feat(print): implement thread-safe debug logging system with FreeRTOS queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,46 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# Build directories
+build/
+debug/
+release/
+Debug/
+Release/
+
+# IDEs and editors
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# STM32CubeIDE specific
+.settings/
+.cproject
+.project
+.mxproject
+
+# Build artifacts
+*.bin
+*.lst
+
+# STM32CubeMX generated files
+Drivers/
+Middlewares/
+Core/Src/system_stm32f7xx.c
+Core/Inc/system_stm32f7xx.h
+
+# Backup files
+*.bak
+*~
+
+# Debug files
+*.launch
+
+# Dependencies
+*.dep
+
+# Misc
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # uart_printf_freertos_stm32
+
 ## STM32F7 Thread-Safe Printf Implementation
 
 A robust thread-safe implementation of printf and scanf for STM32F7 microcontrollers using FreeRTOS and UART.
@@ -6,9 +7,8 @@ A robust thread-safe implementation of printf and scanf for STM32F7 microcontrol
 ## Features
 
 - Thread-safe printf implementation
-- Thread-safe scanf support
-- UART3 communication
-- FreeRTOS mutex protection
+- UART communication (default - UART3)
+- FreeRTOS Queue protection
 - Minimal overhead
 - Easy integration
 
@@ -16,50 +16,142 @@ A robust thread-safe implementation of printf and scanf for STM32F7 microcontrol
 
 - `print.c`: Core implementation of thread-safe IO functions
 - `print.h`: Header file with function declarations
-
-## Requirements
-
-- STM32F7 series microcontroller
-- FreeRTOS
-- Configured UART3
-- HAL drivers
-
-## Usage
-
-1. Add `print.c` and `print.h` to your project
-2. Initialize UART3 in your hardware configuration
-3. Call `print_init()` before starting the scheduler
-4. Use standard `printf()` and `scanf()` functions in your code
-
-## Example
-
+  
 ```c
-#include "print.h"
-#include <stdio.h>
-
-int main(void) {
-    // Initialize peripherals
-    
-    print_init();
-    
-    // Your code here
-    printf("Hello World!\n");
-    
-    // Start scheduler
-}
+#define PRINT_QUEUE_SIZE 64
+#define MAX_PRINT_MSG_LEN 128
 ```
 
+## Feature
+
+- Thread-safe printf implementation using FreeRTOS Queue
+- UART communication (default - UART3)
+- FreeRTOS Queue-based protection
+- Minimal overhead
+- Easy integration
+
+  ## Usage
+
+  Clone the repository:
+
+  ```bash
+  git clone https://github.com/elkanamol/uart_printf_freertos_stm32.git
+  ```
+
+  1. Add the files to your project:
+
+- Copy `print.c` and `print.h` to your source directory
+- Add them to your build system
+  1. Initialize UART3 in your hardware configuration
+  2. Configure queue settings if needed:
+- `PRINT_QUEUE_SIZE`
+- `MAX_PRINT_MSG_LEN`
+  1. Initialize print system before scheduler start
+  2. Use standard `printf()` or `DEBUG_*` macros in your code
+
+  ## Example
+
+  ```c
+  #include "print.h"
+  #include <stdio.h>
+
+  int main(void) {
+      // Initialize peripherals
+      BaseType_t xReturn;
+    
+      // Initialize print system with priority check
+      xReturn = xPrintInit(PRINT_TASK_PRIORITY);
+      if (xReturn != pdPASS) {
+          // Handle initialization error
+          for(;;);
+      }
+
+      // Debug print examples
+      DEBUG_INFO("System initialized\n");
+      DEBUG_WARNING("System warning example\n");
+    
+      // Standard printf usage
+      printf("Hello from printf!\r\n");
+
+      // Start the scheduler
+      vTaskStartScheduler();
+
+      // Should never reach here
+      for(;;);
+  }
+  ```
+
+  The debug print system provides three levels of output:
+  - `DEBUG_ERROR()` - For critical errors
+  - `DEBUG_WARNING()` - For warning conditions
+  - `DEBUG_INFO()` - For general information
+
+  Each debug message includes:
+  - Timestamp
+  - Message level (ERROR/WARN/INFO)
+  - Current task name
+  - User message
+
+  To disable debug prints, comment out:
+
+  ```c
+  #define DEBUG_PRINT_ENABLED
+  ```
+
+  The implementation uses a FreeRTOS queue for thread-safe operation, with configurable timeout and message size limits.
+
+## Debug Print Features
+
+The implementation now includes debug print levels with timestamps and task names:
+
+- ERROR level: `DEBUG_ERROR("message", args...)`
+- WARNING level: `DEBUG_WARNING("message", args...)`
+- INFO level: `DEBUG_INFO("message", args...)`
+
+### Debug Print Usage
+
+```c
+// Enable debug prints by keeping this defined
+#define DEBUG_PRINT_ENABLED
+
+// In your code:
+DEBUG_ERROR("Failed to initialize: %d", error_code);
+DEBUG_WARNING("Battery low: %d%%", battery_level);
+DEBUG_INFO("System started successfully");
+```
+
+Output format: `[timestamp][LEVEL][TaskName] message`
+
+### Disable Debug Prints
+
+Comment out the following line in print.h to disable all debug prints:
+
+```c
+// #define DEBUG_PRINT_ENABLED
+```
+
+## Changelog
+
+### v1.1.0 (Latest)
+
+New Features:
+
+- Added hierarchical debug print system with ERROR, WARNING, and INFO levels
+- Debug prints now include timestamps and FreeRTOS task names
+- Added ability to globally enable/disable debug prints
+- Improved documentation and usage examples
+
+### v1.0.0 (Initial Release)
+
+- Thread-safe printf implementation
+- UART3 communication support
+- FreeRTOS mutex protection
+- Basic print queue system
+
 ## Distribution
+
 The implementation can be used as standalone files or integrated into larger projects.
 
 ## License
-MIT License
 
-Copyright (c) 2025
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+MIT License - see the [LICENSE](LICENSE) file for details.

--- a/print.c
+++ b/print.c
@@ -7,83 +7,183 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-#include "FreeRTOS.h"
-#include "semphr.h"
+#include "print.h"
 
-/* USER CODE BEGIN 0 */
+// #include "FreeRTOS.h"
+// #include "semphr.h"
 
 // this is thread safe impllementation of printf and scanf ussing UART3.
-// this is works only if using with freeRTOS and UART3. 
+// this is works only if using with freeRTOS and UART3.
 // you need to call print_init() before using printf and scanf.
 
 // replace your uart handle with your uart handle.
 extern UART_HandleTypeDef huart3;
 
-// this is the mutex for print_init and print_deinit.
-static SemaphoreHandle_t xPrintMutex = NULL;
+QueueHandle_t xPrintQueue = NULL;     // Queue for printing messages
+TaskHandle_t xPrintTaskHandle = NULL; // Handle for the print task
 
-void print_init(void) {
-    xPrintMutex = xSemaphoreCreateMutex();
-}
+#define PRINT_QUEUE_TIMEOUT_TICKS 10
 
-void print_deinit(void) {
-    if (xPrintMutex != NULL) {
-        vSemaphoreDelete(xPrintMutex);
-        xPrintMutex = NULL;
+/**
+ * @brief The print task that handles sending print messages to the UART.
+ *
+ * This task is responsible for dequeuing print messages from the `xPrintQueue` and
+ * transmitting the message contents to the UART using `HAL_UART_Transmit()`. The
+ * task will block indefinitely waiting for a message to be available in the queue.
+ * After transmitting the message, the task will delay for 1 tick to allow other
+ * tasks to run.
+ *
+ * This task is intended to be created by the `print_init()` function and should
+ * not be started directly.
+ */
+
+static void vStartPrintTask(void *pvParameters)
+{
+    PrintMessage_t message;
+
+    for (;;)
+    {
+        if (xQueueReceive(xPrintQueue, &message, portMAX_DELAY) == pdTRUE)
+        {
+            HAL_UART_Transmit(&huart3, (uint8_t *)message.buffer, message.len, HAL_MAX_DELAY);
+        }
+        vTaskDelay(1);
     }
 }
 
-void print_error(const char * msg)
+/**
+ * @brief Initializes the print subsystem by creating a print queue and a print task.
+ *
+ * This function sets up the necessary infrastructure for the print subsystem to operate.
+ * It creates a queue (`xPrintQueue`) to hold print messages, and a task (`vStartPrintTask`)
+ * that will dequeue messages from the queue and transmit them to the UART.
+ *
+ * The `uxPriority` parameter specifies the priority of the print task. This should be
+ * set to an appropriate value based on the requirements of the system.
+ *
+ * This function should be called during system initialization, before any print operations
+ * are performed.
+ *
+ * @param uxPriority The priority of the print task.
+ * @return pdPASS if the print subsystem was initialized successfully, pdFAIL otherwise.
+ */
+BaseType_t xPrintInit(UBaseType_t uxPriority)
 {
-    printf("%s\n", msg);
-    for(;;);
-}
-
-int __io_putchar(int ch)
-{
-    if (xPrintMutex != NULL) {
-        xSemaphoreTake(xPrintMutex, portMAX_DELAY);
-        HAL_UART_Transmit(&huart3, (uint8_t *)&ch, 1, 0xFFFF);
-        xSemaphoreGive(xPrintMutex);
+    if (uxPriority > configMAX_PRIORITIES - 1)
+    {
+        printf("Error: Invalid priority\n");
+        return pdFAIL;
     }
-    return ch;
+    BaseType_t xReturn = pdPASS;
+
+    xPrintQueue = xQueueCreate(PRINT_QUEUE_SIZE, sizeof(PrintMessage_t));
+    if (xPrintQueue == NULL)
+    {
+        printf("Error creating print queue\n");
+        return pdFAIL;
+    }
+
+    BaseType_t xTaskRetVal = xTaskCreate(vStartPrintTask,
+                                         "PrintTask",
+                                         configMINIMAL_STACK_SIZE * 8,
+                                         NULL,
+                                         uxPriority,
+                                         &xPrintTaskHandle);
+    if (xTaskRetVal != pdPASS)
+    {
+        printf("Error creating print task\n");
+        xReturn = pdFAIL;
+    }
+    if (xReturn == pdFAIL)
+    {
+        vQueueDelete(xPrintQueue);
+        xPrintQueue = NULL;
+    }
+
+    return xReturn;
 }
 
-int _write(int file, char *ptr, int len)
+/**
+ * @brief Deinitializes the print subsystem by destroying the print queue and print task.
+ *
+ * This function cleans up the resources used by the print subsystem. It deletes the print
+ * queue (`xPrintQueue`) and the print task (`xPrintTaskHandle`). This function should be
+ * called when the print subsystem is no longer needed, such as during system shutdown.
+ */
+void print_deinit(void)
 {
-    if (xPrintMutex != NULL) {
-        xSemaphoreTake(xPrintMutex, portMAX_DELAY);
-        HAL_UART_Transmit(&huart3, (uint8_t *)ptr, len, 0xFFFF);
-        xSemaphoreGive(xPrintMutex);
+    if (xPrintQueue != NULL)
+    {
+        vQueueDelete(xPrintQueue);
+        xPrintQueue = NULL;
+    }
+    if (xPrintTaskHandle != NULL)
+    {
+        vTaskDelete(xPrintTaskHandle);
+        xPrintTaskHandle = NULL;
+    }
+}
+
+/**
+ * @brief Prints an error message and enters an infinite loop.
+ *
+ * This function is used to print an error message to the console and then enter an infinite loop,
+ * effectively halting the program execution. This is typically used for critical errors that
+ * the program cannot recover from.
+ *
+ * @param msg The error message to be printed.
+ */
+void print_error(const char *msg)
+{
+    DEBUG_PRINT("ERROR: %s\n", msg);
+    for (;;)
+        ;
+}
+
+/**
+ * @brief Writes a message to the print queue.
+ *
+ * This function copies the provided data buffer to a print message structure and sends it to the print queue.
+ * The length of the message is limited to `MAX_PRINT_MSG_LEN` to ensure the message fits in the print queue.
+ *
+ * @param file Unused parameter, required by the signature of the `_write` function.
+ * @param ptr Pointer to the data buffer to be printed.
+ * @param len Length of the data buffer.
+ * @return The number of bytes written to the print queue.
+ */
+int _write(int __attribute__((unused)) file, char *ptr, int len)
+{
+    PrintMessage_t message;
+
+    if (len > MAX_PRINT_MSG_LEN)
+        len = MAX_PRINT_MSG_LEN;
+
+    memcpy(message.buffer, ptr, len);
+    message.len = len;
+
+    if (xQueueSend(xPrintQueue, &message, PRINT_QUEUE_TIMEOUT_TICKS) != pdPASS)
+    {
+        return 0;
     }
     return len;
 }
-// for scanf
-int _read(int file, char *ptr, int len)
+
+/**
+ * @brief Writes a single character to the print queue.
+ *
+ * This function takes a single character, creates a print message structure with the character,
+ * and sends it to the print queue. It is used as a low-level output function for printing
+ * characters to the console.
+ *
+ * @param ch The character to be printed.
+ * @return The character that was printed.
+ */
+int __io_putchar(int ch)
 {
-    int ch = 0;
+    PrintMessage_t message;
+    message.buffer[0] = ch;
+    message.len = 1;
 
-    if (xPrintMutex != NULL)
-    {
-        xSemaphoreTake(xPrintMutex, portMAX_DELAY);
-
-        HAL_UART_Receive(&huart3, (uint8_t *)&ch, 1, HAL_MAX_DELAY);
-        HAL_UART_Transmit(&huart3, (uint8_t *)&ch, 1, HAL_MAX_DELAY);
-
-        if (ch == 13)
-        {
-            ch = 10;
-            HAL_UART_Transmit(&huart3, (uint8_t *)&ch, 1, HAL_MAX_DELAY);
-        }
-        else if (ch == 8)
-        {
-            ch = 0x30;
-            HAL_UART_Transmit(&huart3, (uint8_t *)&ch, 1, HAL_MAX_DELAY);
-        }
-
-        xSemaphoreGive(xPrintMutex);
-    }
-
-    *ptr = ch;
-    return 1;
+    xQueueSend(xPrintQueue, &message, PRINT_QUEUE_TIMEOUT_TICKS);
+    return ch;
 }

--- a/print.h
+++ b/print.h
@@ -1,60 +1,143 @@
-  #ifndef __PRINT_H
-  #define __PRINT_H
+#ifndef __PRINT_H
+#define __PRINT_H
 
-  #ifdef __cplusplus
-  extern "C" {
-  #endif
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "task.h"
+
+#define PRINT_QUEUE_SIZE 64
+#define MAX_PRINT_MSG_LEN 128
+
+  /* Debug Print Configuration */
+#define DEBUG_PRINT_ENABLED // Comment out to disable all debug prints
+
+  // Debug levels
+  typedef enum
+  {
+    DEBUG_LEVEL_ERROR = 0,
+    DEBUG_LEVEL_WARNING = 1,
+    DEBUG_LEVEL_INFO = 2
+  } DebugLevel_t;
+
+/**
+ * @brief Enables or disables all debug print statements in the project.
+ *
+ * When DEBUG_PRINT_ENABLED is defined, all debug print statements (DEBUG_ERROR, DEBUG_WARNING, DEBUG_INFO)
+ * will be enabled and printed. When it is not defined, all debug print statements will be disabled.
+ */
+#ifdef DEBUG_PRINT_ENABLED
+#define DEBUG_PRINT_LEVEL(level, fmt, ...)                                                   \
+  do                                                                                         \
+  {                                                                                          \
+    TickType_t currentTime = xTaskGetTickCount();                                            \
+    const char *taskName = pcTaskGetName(NULL);                                              \
+    printf("[%lu][%s][%s] " fmt,                                                             \
+           currentTime,                                                                      \
+           (level == DEBUG_LEVEL_ERROR) ? "ERROR" : (level == DEBUG_LEVEL_WARNING) ? "WARN"  \
+                                                                                   : "INFO", \
+           taskName,                                                                         \
+           ##__VA_ARGS__);                                                                   \
+  } while (0)
+
+/**
+ * @brief Prints an error-level debug message with the current task name and timestamp.
+ *
+ * This macro is used to print error-level debug messages. It includes the current task name and the timestamp
+ * of when the message was printed. The message is formatted using the provided format string and arguments.
+ *
+ * @param fmt The format string for the debug message.
+ * @param ... The arguments to be formatted and printed.
+ */
+#define DEBUG_ERROR(fmt, ...) DEBUG_PRINT_LEVEL(DEBUG_LEVEL_ERROR, fmt, ##__VA_ARGS__)
+
+/**
+ * @brief Prints a warning-level debug message with the current task name and timestamp.
+ *
+ * This macro is used to print warning-level debug messages. It includes the current task name and the timestamp
+ * of when the message was printed. The message is formatted using the provided format string and arguments.
+ *
+ * @param fmt The format string for the debug message.
+ * @param ... The arguments to be formatted and printed.
+ */
+#define DEBUG_WARNING(fmt, ...) DEBUG_PRINT_LEVEL(DEBUG_LEVEL_WARNING, fmt, ##__VA_ARGS__)
+
+/**
+ * @brief Prints an info-level debug message with the current task name and timestamp.
+ *
+ * This macro is used to print info-level debug messages. It includes the current task name and the timestamp
+ * of when the message was printed. The message is formatted using the provided format string and arguments.
+ *
+ * @param fmt The format string for the debug message.
+ * @param ... The arguments to be formatted and printed.
+ */
+#define DEBUG_INFO(fmt, ...) DEBUG_PRINT_LEVEL(DEBUG_LEVEL_INFO, fmt, ##__VA_ARGS__)
+#else
+#define DEBUG_ERROR(fmt, ...) ((void)0)   // set to `NULL` to disable all debug prints
+#define DEBUG_WARNING(fmt, ...) ((void)0) // set to `NULL` to disable all debug prints
+#define DEBUG_INFO(fmt, ...) ((void)0)    // set to `NULL` to disable all debug prints
+
+#endif // DEBUG_PRINT_ENABLED
 
   /**
- * @brief Initializes the print functionality with thread-safe mutex
- * @note Must be called before using printf/scanf functions
- */
-  void print_init(void);
+   * @brief Represents a print message to be sent to the print queue.
+   *
+   * This structure holds the `buffer` containing the message to be printed, as well as the length
+   * of the message. It is used to pass print messages between the application and the print task.
+   */
+  typedef struct
+  {
+    char buffer[MAX_PRINT_MSG_LEN];
+    uint16_t len;
+  } PrintMessage_t;
+
+  extern QueueHandle_t xPrintQueue;     // Queue for printing messages. set at print.c
+  extern TaskHandle_t xPrintTaskHandle; // Handle for the print task. set at print.c
 
   /**
- * @brief Deinitializes the print functionality and frees the mutex
- */
+   * @brief Initializes the print subsystem by creating a print queue and a print task.
+   *
+   * This function sets up the necessary infrastructure for the print subsystem to operate.
+   * It creates a queue (`xPrintQueue`) to hold print messages, and a task (`vStartPrintTask`)
+   * that will dequeue messages from the queue and transmit them to the UART.
+   *
+   * The `uxPriority` parameter specifies the priority of the print task. This should be
+   * set to an appropriate value based on the requirements of the system.
+   *
+   * This function should be called during system initialization, before any print operations
+   * are performed.
+   *
+   * @param uxPriority The priority of the print task.
+   * @return `pdPASS` if the print subsystem was initialized successfully, `pdFAIL` otherwise.
+   */
+  BaseType_t xPrintInit(UBaseType_t uxPriority);
+
+  /**
+   * @brief Deinitializes the print subsystem by destroying the print queue and print task.
+   *
+   * This function cleans up the resources used by the print subsystem. It deletes the print
+   * queue (`xPrintQueue`) and the print task (`xPrintTaskHandle`). This function should be
+   * called when the print subsystem is no longer needed, such as during system shutdown.
+   */
   void print_deinit(void);
 
   /**
- * @brief Prints an error message and enters an infinite loop
- * @param msg The error message to print
- */
+   * @brief Prints an error message and enters an infinite loop.
+   *
+   * This function is used to print an error message to the console and then enter an infinite loop,
+   * effectively halting the program execution. This is typically used for critical errors that
+   * the program cannot recover from.
+   *
+   * @param msg The error message to be printed.
+   */
   void print_error(const char *msg);
 
-  /**
- * @brief Low-level character output function (weak)
- * @param ch Character to output
- * @return The character that was output
- * @note This function is called by printf internally
- * @note Can be overridden by user implementation
- */
-  int __io_putchar(int ch);
+#ifdef __cplusplus
+}
+#endif
 
-  /**
- * @brief Low-level write function for stdout (weak)
- * @param file File descriptor (unused)
- * @param ptr Pointer to data buffer
- * @param len Length of data to write
- * @return Number of bytes written
- * @note This function is called by printf internally
- * @note Can be overridden by user implementation
- */
-  int _write(int file, char *ptr, int len);
-
-  /**
- * @brief Low-level read function for stdin (weak)
- * @param file File descriptor (unused)
- * @param ptr Pointer to data buffer
- * @param len Maximum length to read
- * @return Number of bytes read
- * @note This function is called by scanf internally
- * @note Can be overridden by user implementation
- */
-  int _read(int file, char *ptr, int len);
-
-  #ifdef __cplusplus
-  }
-  #endif
-
-  #endif /* __PRINT_H */
+#endif /* __PRINT_H */


### PR DESCRIPTION

- Replace mutex-based implementation with FreeRTOS queue for better thread safety
- Add hierarchical debug logging levels (ERROR, WARNING, INFO) 
- Include timestamps and task names in debug messages
- Add configurable message queue size and timeout settings
- Improve documentation with detailed function descriptions
- Update .gitignore for STM32 development
- Enhance README with new features and usage examples

BREAKING CHANGE: print_init() renamed to xPrintInit() with new priority parameter
